### PR TITLE
chore: Added groups information in the profile endpoint

### DIFF
--- a/backend/workouts/test/test_models.py
+++ b/backend/workouts/test/test_models.py
@@ -317,12 +317,18 @@ class WorkoutStreakModelTest(TestCase):
         """Testa atualização de streak em treinos consecutivos"""
         streak = WorkoutStreak.objects.create(user=self.user)
 
-        # Primeiro treino
-        first_workout = timezone.now() - timedelta(days=2)
+        # Calcular a quarta-feira mais próxima no passado
+        today = timezone.now()
+        days_since_wednesday = (today.weekday() - 2) % 7  # 2 = quarta-feira (0=segunda, 1=terça, 2=quarta...)
+        if days_since_wednesday == 0:  # Se hoje é quarta, pegar quarta da semana passada
+            days_since_wednesday = 7
+
+        # Primeiro treino - sempre numa quarta-feira
+        first_workout = today - timedelta(days=days_since_wednesday)
         streak.update_streak(first_workout)
 
-        # Segundo treino
-        second_workout = timezone.now() - timedelta(days=1)
+        # Segundo treino - dia seguinte (quinta-feira)
+        second_workout = first_workout + timedelta(days=1)
         result = streak.update_streak(second_workout)
 
         self.assertEqual(result, 2)


### PR DESCRIPTION
# Reorganize information in the profile endpoint

In the endpoint that returns the profile, in the groups key, I replaced the list of IDs with an object with the following group information:

- ID
- Name
- Number of members,
- Position within the group