### PR TITLE
Reorganization endpoint group

### DIFF
--- a/.idea/copilotDiffState.xml
+++ b/.idea/copilotDiffState.xml
@@ -30,15 +30,6 @@
             </PendingDiffInfo>
           </value>
         </entry>
-        <entry key="$PROJECT_DIR$/backend/groups/serializer.py">
-          <value>
-            <PendingDiffInfo>
-              <option name="filePath" value="$PROJECT_DIR$/backend/groups/serializer.py" />
-              <option name="originalContent" value="from rest_framework import serializers&#10;&#10;from groups.models import Group, GroupMembers&#10;&#10;&#10;class GroupSerializer(serializers.ModelSerializer):&#10;    class Meta:&#10;        model = Group&#10;        fields = '__all__'&#10;&#10;&#10;class GroupMemberSerializer(serializers.ModelSerializer):&#10;    class Meta:&#10;        model = GroupMembers&#10;        fields = ['member', 'joined_at', 'is_admin']&#10;        read_only_fields = ['member', 'joined_at']&#10;&#10;    def validate(self, attrs):&#10;        &quot;&quot;&quot;&#10;        Custom validation to check that read-only fields are not provided.&#10;        &quot;&quot;&quot;&#10;        if 'joined_at' in self.initial_data:&#10;            raise serializers.ValidationError({&#10;                &quot;joined_at&quot;: &quot;This field is read-only and cannot be modified.&quot;&#10;            })&#10;&#10;        return attrs&#10;" />
-              <option name="updatedContent" value="from rest_framework import serializers&#10;&#10;from groups.models import Group, GroupMembers&#10;&#10;&#10;class GroupSerializer(serializers.ModelSerializer):&#10;    &quot;&quot;&quot;&#10;    Serializer for Group model.&#10;    Handles serialization/deserialization of group data for API endpoints.&#10;    &quot;&quot;&quot;&#10;    class Meta:&#10;        model = Group&#10;        fields = '__all__'  # Include all model fields in serialization&#10;&#10;&#10;class GroupMemberSerializer(serializers.ModelSerializer):&#10;    &quot;&quot;&quot;&#10;    Serializer for GroupMembers model.&#10;    Controls which fields can be modified and validates member data.&#10;    Only allows updating admin status, while member and join date are read-only.&#10;    &quot;&quot;&quot;&#10;    class Meta:&#10;        model = GroupMembers&#10;        fields = ['member', 'joined_at', 'is_admin']&#10;        read_only_fields = ['member', 'joined_at']  # Prevent modification of member and join date&#10;&#10;    def validate(self, attrs):&#10;        &quot;&quot;&quot;&#10;        Custom validation to ensure read-only fields are not provided in requests.&#10;        Prevents clients from attempting to modify protected fields.&#10;        &quot;&quot;&quot;&#10;        if 'joined_at' in self.initial_data:&#10;            raise serializers.ValidationError({&#10;                &quot;joined_at&quot;: &quot;This field is read-only and cannot be modified.&quot;&#10;            })&#10;&#10;        return attrs" />
-            </PendingDiffInfo>
-          </value>
-        </entry>
         <entry key="$PROJECT_DIR$/backend/groups/views.py">
           <value>
             <PendingDiffInfo>

--- a/backend/groups/serializer.py
+++ b/backend/groups/serializer.py
@@ -8,9 +8,40 @@ class GroupSerializer(serializers.ModelSerializer):
     Serializer for Group model.
     Handles serialization/deserialization of group data for API endpoints.
     """
+
+    members = serializers.SerializerMethodField()
+
     class Meta:
         model = Group
-        fields = '__all__'  # Include all model fields in serialization
+        fields = [
+            'id',
+            'name',
+            'description',
+            'created_by',
+            'owner',
+            'invite_code',
+            'created_at',
+            'created_by',
+            'members'
+        ]  # Include all model fields in serialization
+        read_only_fields = ['created_by', 'invite_code', 'created_at', 'created_by', 'members']  # Prevent modification of read-only fields
+
+    def get_members(self, obj):
+        """
+        Retrieve and serialize the members of the group.
+        Uses GroupMemberSerializer to represent each member.
+        """
+        members = GroupMembers.objects.filter(group=obj).select_related('member')
+
+        return [{
+                "id": member.member.id,
+                "username": member.member.username,
+                "email": member.member.email,
+                "is_admin": member.is_admin,
+                "joined_at": member.joined_at
+            }
+            for member in members
+        ]
 
 
 class GroupMemberSerializer(serializers.ModelSerializer):

--- a/backend/groups/serializer.py
+++ b/backend/groups/serializer.py
@@ -21,17 +21,16 @@ class GroupSerializer(serializers.ModelSerializer):
             'owner',
             'invite_code',
             'created_at',
-            'created_by',
             'members'
         ]  # Include all model fields in serialization
-        read_only_fields = ['created_by', 'invite_code', 'created_at', 'created_by', 'members']  # Prevent modification of read-only fields
+        read_only_fields = ['created_by', 'invite_code', 'created_at', 'members']  # Prevent modification of read-only fields
 
     def get_members(self, obj):
         """
         Retrieve and serialize the members of the group.
         Uses GroupMemberSerializer to represent each member.
         """
-        members = GroupMembers.objects.filter(group=obj).select_related('member')
+        members = obj.groupmembers_set.all().select_related('member')
 
         return [{
                 "id": member.member.id,

--- a/backend/groups/test/test_urls.py
+++ b/backend/groups/test/test_urls.py
@@ -12,10 +12,6 @@ class TestUrls(TestCase):
         url = reverse('groups-detail', kwargs={'pk': 1})
         self.assertEqual(resolve(url).view_name, 'groups-detail')
 
-    def test_group_members_url(self):
-        url = reverse('group-members-list', kwargs={'group_id': 1})
-        self.assertEqual(resolve(url).view_name, 'group-members-list')
-
     def test_group_member_url(self):
         url = reverse('group-members-detail', kwargs={'group_id': 1, 'member_id': 1})
         self.assertEqual(resolve(url).view_name, 'group-members-detail')

--- a/backend/groups/test/test_views.py
+++ b/backend/groups/test/test_views.py
@@ -7,7 +7,6 @@ from groups.models import Group, GroupMembers
 from groups.views import (
     GroupsAPIView,
     GroupAPIView,
-    GroupMembersAPIView,
     GroupMemberAPIView,
     JoinGroupAPIView
 )
@@ -78,14 +77,6 @@ class GroupViewsTest(TestCase):
         response = GroupAPIView.as_view()(request, pk=self.group.id)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Group.objects.filter(id=self.group.id).exists())
-
-    def test_list_group_members(self):
-        request = self.factory.get(f'/groups/{self.group.id}/members/')
-        force_authenticate(request, user=self.user1)
-        response = GroupMembersAPIView.as_view()(request, group_id=self.group.id)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Two members: user1 (admin) and user2
-        self.assertEqual(len(response.data), 2)
 
     def test_retrieve_group_member(self):
         request = self.factory.get(f'/groups/{self.group.id}/members/{self.user2.id}/')

--- a/backend/groups/urls.py
+++ b/backend/groups/urls.py
@@ -1,10 +1,9 @@
 from django.urls import path
-from .views import GroupsAPIView, GroupAPIView, GroupMembersAPIView, JoinGroupAPIView, GroupMemberAPIView
+from .views import GroupsAPIView, GroupAPIView, JoinGroupAPIView, GroupMemberAPIView
 
 urlpatterns = [
     path('', GroupsAPIView.as_view(), name='groups-list'),
     path('<int:pk>/', GroupAPIView.as_view(), name='groups-detail'),
-    path('<int:group_id>/members/', GroupMembersAPIView.as_view(), name='group-members-list'),
     path('<int:group_id>/members/<int:member_id>/', GroupMemberAPIView.as_view(), name='group-members-detail'),
     path('join/<str:invite_code>/', JoinGroupAPIView.as_view(), name='join-group'),
 ]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -55,24 +55,6 @@ class GroupAPIView(RetrieveUpdateDestroyAPIView):
 
 
 @extend_schema(tags=['Groups'])
-class GroupMembersAPIView(ListAPIView):
-    """
-    API view for listing all members of a specific group.
-    Read-only endpoint that returns group membership information.
-    """
-    serializer_class = GroupMemberSerializer
-    permission_classes = [IsAuthenticated]
-    http_method_names = ['get']  # Only allow GET requests
-
-    def get_queryset(self):
-        """
-        Return all members for the specified group.
-        Filters members by group ID from URL parameters.
-        """
-        return GroupMembers.objects.filter(group_id=self.kwargs['group_id'])
-
-
-@extend_schema(tags=['Groups'])
 class GroupMemberAPIView(RetrieveUpdateDestroyAPIView):
     """
     API view for individual group member operations.


### PR DESCRIPTION
# Reorganization of the endpoint group

- Altered endpoints and the information in this endpoints from groups app.

- Endpoint of the groups members list deleted and informations from this endpoint go to groups/id endpoint, therefore this endpoint return became the following:

```
[
    {
        "id": int,
        "name": string,
        "description": string,
        "created_by": int,
        "owner": int,
        "invite_code": string,
        "created_at": string,
        "created_by": id,
        "members": [
            {
                "id": int,
                "username": string,
                "email": string,
                "is_admin": bool,
                "joined_at": string
            },
        ]
    }
]
```

* The `owner` is ID from owner of the group.
* Also deleted tests the referenced the URL and the view from the deleted endpoint



