### PR TITLE
Implement workout XP blocks, meal diet break flag, and aggregated reports

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__obsidian__view"
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+> Configurações do projeto para o time de agentes. Complementa e sobrescreve o copilot-instructions.md global quando necessário.
+
+# Projeto: Xpump
+
+- Nome: Xpump
+- Descrição: Plataforma web gamificada de acompanhamento de fitness e nutrição para grupos privados (B2B). PWA.
+- Stack: Frontend: Next.js. Backend: Django + DRF (backend/).
+- Repositório: C:\Users\bruno\Desktop\Projetos\Xpump
+
+## Ambiente local (sugestões)
+- Backend: cd backend && python manage.py runserver 0.0.0.0:8000
+
+## Vault (Obsidian)
+- Path do projeto: Dev projects/Xpump
+- Memory: Dev projects/Xpump/memory.md
+- Planejamentos: Dev projects/Xpump/features/ (se existir)
+
+## Branches protegidas
+- Nunca commitar diretamente em: main (principal), master (secundária)
+
+## Como rodar os testes
+- Backend: cd backend && python manage.py test
+
+## Ownership dos agentes
+- backend/: views.py, api/, serializers.py, services.py, management/, templates/, static/
+- dba: backend/: models.py, migrations/, fixtures/, db_schema/
+- qa: tests/: backend/tests/
+- security: docs/security/, backend/authentication/
+- reviewer: Revisão de PRs, comentários, qualidade do código
+
+## Convenções
+- Commits: tipo(escopo): mensagem imperativa curta (feat, fix, refactor, test, docs, chore, perf, style)
+- Leia Dev projects/_memory.md e Dev projects/Xpump/memory.md antes de iniciar tarefas.
+- Não sobrescrever ADRs existentes; adicione novos ADRs quando necessário.
+
+---
+
+> Observação: este ficheiro é um rascunho de instruções para agentes. Edite conforme necessário antes de torná-lo padrão para o repositório.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# AGENTS.md — Xpump
+
+> Configurações do projeto para o time de agentes.
+> Complementa e sobrescreve o AGENTS.md global quando necessário.
+
+---
+
+## Projeto
+
+**Nome:** Xpump  
+**Descrição:** plataforma gamificada de fitness e nutrição com backend Django para grupos privados  
+**Stack:** Monorepo com backend Django/DRF e frontend Next.js; este AGENTS.md cobre operacionalmente apenas o `backend/`  
+**Repositório:** https://github.com/BrunoFurlanetto/xpump.git  
+**Ambiente local:** `cd backend && python manage.py runserver`
+
+---
+
+## Escopo deste AGENTS
+
+Este projeto é um monorepo, mas o escopo de atuação configurado aqui é **somente o backend**.
+
+Tudo em `frontend/` deve ser tratado como fora de ownership deste setup, exceto leitura quando necessário para entender integração.
+
+---
+
+## Vault (Obsidian)
+
+**Path do projeto:** `Dev projects/Xpump`  
+**Memory:** `Dev projects/Xpump/Memory.md`  
+**Session Log:** `Dev projects/Xpump/session-log.md`  
+**Planejamentos:** `Dev projects/Xpump/features/`
+
+### Abertura de sessão
+
+Ler em paralelo antes de qualquer task:
+
+```text
+mcp_obsidian: view
+path: Dev projects/Xpump/Memory.md
+```
+
+```text
+mcp_obsidian: view
+path: Dev projects/Xpump/session-log.md
+```
+
+Priorizar na leitura:
+- `session-log.md` — última entrada, pendências e bloqueios
+- `Memory.md` — ADRs, problemas conhecidos e padrões do projeto
+
+Se a task envolve uma feature planejada no vault, ler também:
+
+```text
+mcp_obsidian: view
+path: Dev projects/Xpump/features/<nome-da-feature>.md
+```
+
+### Declaração obrigatória antes de agir
+
+Após a leitura, declarar:
+
+```text
+Contexto da última sessão: [feature], status [✅/🔄/🔴], pendente: [o quê].
+Minha task agora: [o que vou fazer].
+```
+
+### Fechamento de sessão
+
+Seguir o protocolo condicional do AGENTS global. Quando houver registro, adicionar ao final de `Dev projects/Xpump/session-log.md`.
+
+Se houver decisão de design relevante, registrar primeiro no `Dev projects/Xpump/Memory.md` e só depois fechar a sessão.
+
+---
+
+## Branches protegidas
+
+Nunca commitar diretamente ou criar branches a partir de:
+- `main`
+- `master`
+
+O orchestrator sempre pergunta a branch base antes de criar qualquer branch nova.
+
+---
+
+## Como rodar os testes
+
+```bash
+cd backend && python manage.py test
+```
+
+---
+
+## Ownership dos agentes
+
+| Agente | Pode criar/editar | Somente leitura |
+|--------|-------------------|-----------------|
+| `dev` | `backend/<app>/views.py`, `backend/<app>/urls.py`, `backend/<app>/serializer.py`, `backend/<app>/serializers.py`, `backend/<app>/services.py`, `backend/<app>/permissions.py`, `backend/<app>/exceptions.py`, `backend/<app>/pagination.py`, `backend/<app>/management/commands/`, `backend/core/urls.py`, `backend/core/storage_backends.py` | `backend/<app>/models.py`, `backend/<app>/migrations/`, `frontend/` |
+| `dba` | `backend/<app>/models.py`, `backend/<app>/migrations/`, `backend/fixtures/` | todo o restante |
+| `qa` | `backend/**/tests.py`, `backend/**/test/`, testes de integração do backend | código de produção |
+| `security` | `docs/security/` e relatórios de segurança do backend | todo o codebase |
+| `reviewer` | — | todo o codebase |
+
+Apps backend atualmente detectados:
+- `authentication`
+- `profiles`
+- `groups`
+- `workouts`
+- `nutrition`
+- `gamification`
+- `clients`
+- `social_feed`
+- `analytics`
+- `notifications`
+- `status`
+
+---
+
+## Convenções
+
+### Commits
+
+```text
+tipo(escopo): mensagem imperativa curta
+
+Task: T-xxx
+```
+
+Tipos válidos: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `style`
+
+### Backend Django
+
+- Estrutura principal em `backend/`, com projeto Django em `backend/core/`
+- APIs expostas sob prefixo `api/v1/` em `backend/core/urls.py`
+- Documentação OpenAPI via `drf-spectacular`
+- Autenticação com `JWTAuthentication` e `SessionAuthentication`
+- Banco configurado para PostgreSQL por variáveis de ambiente
+- Uploads e storage configurados para Cloudflare R2 em produção
+- Há comandos de gerenciamento por app em `management/commands/`
+- Os testes estão distribuídos entre `tests.py` e pastas `test/` por app
+
+### Variáveis e integrações relevantes
+
+Detectadas em `backend/core/settings.py`:
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_HOST`
+- `DB_PORT`
+- `SECRET_KEY`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_STORAGE_BUCKET_NAME`
+- `AWS_S3_ENDPOINT_URL`
+- `AWS_S3_CUSTOM_DOMAIN`
+- `VAPID_PRIVATE_KEY`
+- `VAPID_PUBLIC_KEY`
+- `VAPID_ADMIN_EMAIL`
+
+### Convenções de sessão no vault
+
+- O projeto já usa `Memory.md` com `M` maiúsculo; manter esse nome até eventual padronização explícita
+- O `session-log.md` já existe e deve receber apenas append no final
+- Agentes não devem sobrescrever entradas anteriores no vault

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,170 @@
+# CLAUDE.md — Xpump
+
+> Configurações do projeto para o time de agentes.
+> Complementa e sobrescreve o CLAUDE.md global quando necessário.
+
+---
+
+## Projeto
+
+**Nome:** Xpump
+**Descrição:** Plataforma gamificada de fitness e nutrição com backend Django para privados
+**Stack:** Django 5.2.3 · DRF · PostgreSQL · JWT (SimpleJWT) · Cloudflare R2 · APScheduler
+**Repositório:** https://github.com/BrunoFurlanetto/xpump.git
+**Ambiente local:** `cd backend && python manage.py runserver`
+
+---
+
+## Vault (Obsidian)
+
+**Path do projeto:** Dev projects/Xpump
+**Memory:** Dev projects/Xpump/Memory.md
+**Session Log:** Dev projects/Xpump/session-log.md
+**Planejamentos:** Dev projects/Xpump/features/
+
+### Abertura de sessão
+
+Ler em paralelo antes de qualquer task:
+
+```
+mcp_obsidian: read_note
+path: Dev projects/Xpump/Memory.md
+```
+
+```
+mcp_obsidian: read_note
+path: Dev projects/Xpump/session-log.md
+```
+
+Priorizar na leitura:
+- `session-log.md` — última entrada: o que estava em andamento e o que está pendente
+- `memory.md` — ADRs relevantes à task atual, problemas conhecidos, padrões estabelecidos
+
+Se a task envolve um planejamento de feature, ler também:
+```
+mcp_obsidian: read_note
+path: Dev projects/Xpump/features/<nome-da-feature>.md
+```
+
+Ler a nota do módulo afetado antes de implementar:
+```
+mcp_obsidian: read_note
+path: Dev projects/Xpump/modules/{app}/{app}.md
+```
+
+### Fechamento de sessão
+
+Seguir o protocolo condicional do CLAUDE.md global. Quando registrar:
+
+```
+mcp_obsidian: update_note
+path: Dev projects/Xpump/session-log.md
+```
+
+Se tomou decisão de design, registrar ADR no `memory.md` antes de fechar:
+
+```
+mcp_obsidian: update_note
+path: Dev projects/Xpump/Memory.md
+```
+
+---
+
+## Branches protegidas
+
+Nunca commitar diretamente ou criar branches a partir de:
+- `main`
+
+O orchestrator sempre pergunta a branch base antes de criar qualquer branch nova.
+
+---
+
+## Como rodar os testes
+
+```bash
+cd backend && python manage.py test
+```
+
+---
+
+## Ownership dos agentes
+
+| Agente | Pode criar/editar | Somente leitura |
+|--------|------------------|-----------------|
+| `dev` | `{app}/views.py`, `{app}/urls.py`, `{app}/serializer.py`, `{app}/services.py`, `{app}/signals.py`, `{app}/pagination.py`, `{app}/permissions.py`, `{app}/exceptions.py`, `{app}/scheduler.py`, `{app}/management/`, `core/urls.py`, `core/settings.py` | models, migrations, testes |
+| `dba` | `{app}/models.py`, `{app}/migrations/`, `{app}/admin.py`, `{app}/fixtures/` | todo o resto |
+| `qa` | `{app}/test/`, `{app}/tests.py` | todo o código de produção |
+| `security` | `docs/security/` | todo o codebase |
+| `reviewer` | — | todo o codebase |
+
+---
+
+## Convenções
+
+### Commits
+
+```
+tipo(escopo): mensagem imperativa curta
+
+Task: T-xxx
+```
+
+Tipos válidos: feat, fix, refactor, test, docs, chore, perf, style
+
+### Estrutura de cada app Django
+
+```
+{app}/
+├── models.py           # dba
+├── migrations/         # dba
+├── admin.py            # dba
+├── serializer.py       # dev — sempre singular, sem "s"
+├── views.py            # dev
+├── urls.py             # dev
+├── services.py         # dev (quando necessário)
+├── permissions.py      # dev (quando necessário)
+├── exceptions.py       # dev (quando necessário)
+├── signals.py          # dev (quando necessário)
+├── pagination.py       # dev (quando necessário)
+└── test/               # qa
+    ├── test_models.py
+    ├── test_serializers.py
+    ├── test_views.py
+    └── test_urls.py
+```
+
+> `profiles/serializers.py` e `social_feed/serializers.py` usam plural por engano histórico.
+> Padrão correto é singular. Novos arquivos sempre com `serializer.py`.
+
+### Apps e responsabilidades
+
+| App | Responsabilidade |
+|-----|-----------------|
+| `core` | Settings, URLs raiz, storage backends, WSGI/ASGI |
+| `authentication` | Login, JWT tokens, criação de usuários |
+| `profiles` | Perfis de usuário, atividades, scores |
+| `clients` | Clientes/academias que usam a plataforma |
+| `groups` | Grupos e desafios entre usuários |
+| `workouts` | Cadastro e registro de treinos |
+| `nutrition` | Cadastro e registro de refeições |
+| `gamification` | XP, níveis, seasons, badges |
+| `social_feed` | Posts, feed social, curtidas |
+| `analytics` | Dados analíticos e relatórios |
+| `notifications` | Push notifications via APScheduler |
+| `status` | Statuses configuráveis do sistema |
+
+### URLs
+
+Todas as rotas seguem prefixo `api/v1/`. Exemplo: `api/v1/profiles/`, `api/v1/groups/`.
+
+### Variáveis de ambiente obrigatórias
+
+```
+SECRET_KEY
+DB_NAME · DB_USER · DB_PASSWORD · DB_HOST · DB_PORT
+AWS_ACCESS_KEY_ID · AWS_SECRET_ACCESS_KEY · AWS_STORAGE_BUCKET_NAME
+AWS_S3_ENDPOINT_URL · AWS_S3_CUSTOM_DOMAIN (opcional)
+VAPID_PRIVATE_KEY · VAPID_PUBLIC_KEY · VAPID_ADMIN_EMAIL
+```
+
+Em desenvolvimento usar `backend/core/local_settings.py` (não versionado).

--- a/backend/.claude/settings.local.json
+++ b/backend/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git -C \"C:/Users/bruno/Desktop/Projetos/Xpump\" remote get-url origin)"
+    ]
+  }
+}

--- a/backend/analytics/services.py
+++ b/backend/analytics/services.py
@@ -604,7 +604,10 @@ class SystemAnalyticsService:
         likes_this_week = (post_like_stats['week'] or 0) + (comment_like_stats['week'] or 0)
         likes_this_month = (post_like_stats['month'] or 0) + (comment_like_stats['month'] or 0)
 
-        pending_reports = Report.objects.filter(status='pending').count()
+        pending_reports = (
+            Report.objects.filter(status='pending', post__isnull=False).values('post_id').distinct().count() +
+            Report.objects.filter(status='pending', comment__isnull=False).values('comment_id').distinct().count()
+        )
 
         # Gamification statistics
         profile_stats = Profile.objects.filter(

--- a/backend/analytics/test/test_services.py
+++ b/backend/analytics/test/test_services.py
@@ -20,6 +20,7 @@ from profiles.models import Profile
 from groups.models import Group, GroupMembers
 from workouts.models import WorkoutCheckin, WorkoutStreak
 from nutrition.models import MealStreak
+from social_feed.models import Post, Comment, Report
 
 
 faker = Faker('pt_BR')
@@ -384,6 +385,34 @@ class SystemAnalyticsServiceTest(TestCase):
 
         self.assertEqual(stats['total_workouts'], 1)
         self.assertEqual(stats['workouts_today'], 1)
+
+    def test_get_system_stats_counts_pending_reports_by_unique_item(self):
+        """Pending reports devem contar itens únicos, não ocorrências individuais."""
+        post = Post.objects.create(
+            user=self.user,
+            content_type='social',
+            content_text='Reported post',
+            visibility='global'
+        )
+        comment = Comment.objects.create(
+            user=self.user,
+            post=post,
+            text='Reported comment'
+        )
+        reviewer = User.objects.create_user(
+            username='reviewer',
+            email='reviewer@example.com',
+            password='testpass123'
+        )
+        Profile.objects.create(user=reviewer, score=0, level=1, employer=self.client)
+
+        Report.objects.create(report_type='post', post=post, reported_by=self.user, reason='spam', status='pending')
+        Report.objects.create(report_type='post', post=post, reported_by=reviewer, reason='fake', status='pending')
+        Report.objects.create(report_type='comment', comment=comment, reported_by=self.user, reason='harassment', status='pending')
+
+        stats = SystemAnalyticsService.get_system_stats()
+
+        self.assertEqual(stats['pending_reports'], 2)
 
 
 class ActivityFeedServiceTest(TestCase):

--- a/backend/gamification/migrations/0015_update_workout_defaults.py
+++ b/backend/gamification/migrations/0015_update_workout_defaults.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def update_existing_workout_defaults(apps, schema_editor):
+    GamificationSettings = apps.get_model('gamification', 'GamificationSettings')
+    GamificationSettings.objects.all().update(workout_minutes=30, workout_xp=1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gamification', '0014_remove_gamificationbonus_gamificatio_user_id_3ed35b_idx_and_mor'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='gamificationsettings',
+            name='workout_minutes',
+            field=models.IntegerField(default=30, help_text='Minutos de treino que equivalem a um bloco de pontuação'),
+        ),
+        migrations.AlterField(
+            model_name='gamificationsettings',
+            name='workout_xp',
+            field=models.IntegerField(default=1, help_text='XP concedido por cada bloco completo de treino'),
+        ),
+        migrations.RunPython(update_existing_workout_defaults, migrations.RunPython.noop),
+    ]

--- a/backend/gamification/migrations/0015_update_workout_defaults.py
+++ b/backend/gamification/migrations/0015_update_workout_defaults.py
@@ -1,11 +1,6 @@
 from django.db import migrations, models
 
 
-def update_existing_workout_defaults(apps, schema_editor):
-    GamificationSettings = apps.get_model('gamification', 'GamificationSettings')
-    GamificationSettings.objects.all().update(workout_minutes=30, workout_xp=1)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -23,5 +18,4 @@ class Migration(migrations.Migration):
             name='workout_xp',
             field=models.IntegerField(default=1, help_text='XP concedido por cada bloco completo de treino'),
         ),
-        migrations.RunPython(update_existing_workout_defaults, migrations.RunPython.noop),
     ]

--- a/backend/gamification/models.py
+++ b/backend/gamification/models.py
@@ -78,8 +78,8 @@ class GamificationSettings(models.Model):
     xp_base = models.IntegerField(default=6, help_text="XP base para o nível 1")
     exponential_factor = models.FloatField(default=1.5, help_text="Fator exponencial para cálculo de XP")
     max_level = models.IntegerField(default=50, help_text="Nível máximo permitido")
-    workout_minutes = models.IntegerField(default=50, help_text="Minutos de treino para recompensar o XP estipulado")
-    workout_xp = models.IntegerField(default=2, help_text="XP concedido por completar exatos minutos de treino")
+    workout_minutes = models.IntegerField(default=30, help_text="Minutos de treino que equivalem a um bloco de pontuação")
+    workout_xp = models.IntegerField(default=1, help_text="XP concedido por cada bloco completo de treino")
     max_workout_xp = models.IntegerField(default=4, help_text="XP máximo concedido por treino e por dia")
     multiplier_workout_streak = models.JSONField(
         default=default_multiplier_workout_streak,

--- a/backend/gamification/services.py
+++ b/backend/gamification/services.py
@@ -112,7 +112,7 @@ class WorkoutGamification(GamificationService):
 
     def _calculate_day_total_points(self, user, total_duration_min):
         workout_minutes_base = self.settings.workout_minutes
-        base_points = self.settings.workout_xp
+        base_points = self.base_xp(user)
         multiplier = self.get_multiplier(user)
         completed_blocks = floor(total_duration_min / workout_minutes_base) if workout_minutes_base > 0 else 0
         points_today = float(completed_blocks * base_points) * multiplier

--- a/backend/gamification/services.py
+++ b/backend/gamification/services.py
@@ -111,18 +111,11 @@ class WorkoutGamification(GamificationService):
         return "multiplier_workout_streak"
 
     def _calculate_day_total_points(self, user, total_duration_min):
-        base_points = self.base_xp(user)
         workout_minutes_base = self.settings.workout_minutes
+        base_points = self.settings.workout_xp
         multiplier = self.get_multiplier(user)
-
-        if total_duration_min < workout_minutes_base:
-            points_today = float(base_points / 2) * multiplier
-        elif total_duration_min == workout_minutes_base:
-            points_today = float(base_points) * multiplier
-        elif workout_minutes_base < total_duration_min < workout_minutes_base * 2:
-            points_today = float(base_points * 1.5) * multiplier
-        else:
-            points_today = float(base_points * 2) * multiplier
+        completed_blocks = floor(total_duration_min / workout_minutes_base) if workout_minutes_base > 0 else 0
+        points_today = float(completed_blocks * base_points) * multiplier
 
         return min(points_today, float(self.settings.max_workout_xp))
 

--- a/backend/gamification/test/test_integration.py
+++ b/backend/gamification/test/test_integration.py
@@ -21,8 +21,9 @@ class WorkoutGamificationIntegrationTest(TestCase):
 
     def setUp(self):
         self.settings = GamificationSettings.load()
-        self.settings.workout_xp = 5
-        self.settings.workout_minutes = 60
+        self.settings.workout_xp = 1
+        self.settings.workout_minutes = 30
+        self.settings.max_workout_xp = 10
         self.settings.save()
 
         self.user = User.objects.create_user(username='testuser', password='pass')
@@ -66,7 +67,7 @@ class WorkoutGamificationIntegrationTest(TestCase):
     def test_workout_xp_calculation_with_streak(self):
         """Test XP calculation for workout with streak multiplier"""
         # Create workout
-        duration = timedelta(minutes=90)  # 1.5x base workout time
+        duration = timedelta(minutes=90)
 
         # Mock season to avoid actual season lookup
         with patch('gamification.services.Season.objects.get') as mock_season:
@@ -75,11 +76,8 @@ class WorkoutGamificationIntegrationTest(TestCase):
 
             xp_earned = self.workout_gamification.calculate(self.user, duration, timezone.now())
 
-            # Should be base_xp * duration_ratio * multiplier
-            # With streak=10, multiplier should be 1.5 (based on default settings)
-            # expected_multiplier = 1.5 TODO: Temporaly multiplier is defined as 1.0
             expected_multiplier = 1.0
-            expected_xp = 5 * (90 / 60) * expected_multiplier  # 5 * 1.5 * 1.5 = 11.25
+            expected_xp = 3 * expected_multiplier
 
             self.assertAlmostEqual(xp_earned, expected_xp, places=2)
 

--- a/backend/gamification/test/tests.py
+++ b/backend/gamification/test/tests.py
@@ -22,10 +22,10 @@ class GamificationSettingsModelTest(TestCase):
         self.assertEqual(settings.xp_base, 6)
         self.assertEqual(settings.exponential_factor, 1.5)
         self.assertEqual(settings.max_level, 50)
-        self.assertEqual(settings.workout_minutes, 50)
-        self.assertEqual(settings.workout_xp, 2)
+        self.assertEqual(settings.workout_minutes, 30)
+        self.assertEqual(settings.workout_xp, 1)
         self.assertEqual(settings.meal_xp, 1)
-        self.assertEqual(settings.months_to_end_season, 2)
+        self.assertEqual(settings.days_to_end_month, 10)
         self.assertEqual(settings.season_bonus_percentage, 50.0)
         self.assertEqual(settings.percentage_from_first_position, 60.0)
 
@@ -98,7 +98,7 @@ class WorkoutGamificationTest(TestCase):
         )
 
         # Create settings for this test
-        self.settings = GamificationSettings.objects.create(workout_xp=3)
+        self.settings = GamificationSettings.objects.create(workout_xp=1, workout_minutes=30, max_workout_xp=4)
         self.gamification = WorkoutGamification()
 
     def test_get_streak(self):
@@ -126,6 +126,18 @@ class WorkoutGamificationTest(TestCase):
 
         self.assertIsInstance(result, float)
         self.assertGreater(result, 0)
+
+    def test_calculate_uses_completed_30_minute_blocks(self):
+        """Test XP calculation by completed 30-minute blocks."""
+        workout_date = datetime.now()
+
+        result_29 = self.gamification.calculate(self.user, timedelta(minutes=29), workout_date)
+        result_30 = self.gamification.calculate(self.user, timedelta(minutes=30), workout_date)
+        result_90 = self.gamification.calculate(self.user, timedelta(minutes=90), workout_date)
+
+        self.assertEqual(result_29, 0.0)
+        self.assertEqual(result_30, 1.0)
+        self.assertEqual(result_90, 3.0)
 
     def test_calculate_invalid_args(self):
         """Test calculate method with invalid arguments"""

--- a/backend/gamification/test/tests.py
+++ b/backend/gamification/test/tests.py
@@ -139,6 +139,15 @@ class WorkoutGamificationTest(TestCase):
         self.assertEqual(result_30, 1.0)
         self.assertEqual(result_90, 3.0)
 
+    def test_calculate_keeps_bonus_aware_base_xp(self):
+        """Test workout block calculation still uses bonus-aware base XP."""
+        workout_date = datetime.now()
+
+        with patch.object(self.gamification, 'base_xp', return_value=2.5):
+            result_60 = self.gamification.calculate(self.user, timedelta(minutes=60), workout_date)
+
+        self.assertEqual(result_60, 5.0)
+
     def test_calculate_invalid_args(self):
         """Test calculate method with invalid arguments"""
         result = self.gamification.calculate(self.user)

--- a/backend/nutrition/migrations/0006_meal_broke_diet.py
+++ b/backend/nutrition/migrations/0006_meal_broke_diet.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nutrition', '0005_meal_groups'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='meal',
+            name='broke_diet',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/nutrition/models.py
+++ b/backend/nutrition/models.py
@@ -57,6 +57,7 @@ class Meal(models.Model):
     validation_status = models.ForeignKey(Status, on_delete=models.PROTECT, default=get_published_status_id)
     base_points = models.FloatField(null=True, blank=True, editable=False)
     fasting = models.BooleanField(default=False)
+    broke_diet = models.BooleanField(default=False)
     multiplier = models.FloatField(default=1.0)
     groups = models.ManyToManyField('groups.Group', blank=True)
 
@@ -71,28 +72,38 @@ class Meal(models.Model):
             'action': 'PUBLISHED',
         })
 
+        meal_datetime = self.meal_time.astimezone()
+        streak_defaults = {
+            'current_streak': 0 if self.broke_diet else 1,
+            'longest_streak': 0 if self.broke_diet else 1,
+            'last_meal_datetime': meal_datetime,
+        }
         streak, created = MealStreak.objects.get_or_create(
             user=self.user,
-            defaults={
-                'current_streak': 1,
-                'longest_streak': 1,
-                'last_meal_datetime': self.meal_time.astimezone(),
-            }
+            defaults=streak_defaults
         )
 
         if not created:
-            streak.update_streak(self.meal_time.astimezone())
+            if self.broke_diet:
+                streak.break_streak(meal_datetime)
+            else:
+                streak.update_streak(meal_datetime)
 
         # Calculate multiplier and points based on streak
-        self.multiplier = Gamification.Meal.get_multiplier(self.user)
-        self.base_points = Gamification.Meal.calculate(self.user)
+        if self.broke_diet:
+            self.multiplier = 1.0
+            self.base_points = 0.0
+        else:
+            self.multiplier = Gamification.Meal.get_multiplier(self.user)
+            self.base_points = Gamification.Meal.calculate(self.user)
 
         super().save(*args, **kwargs)
 
         self.groups.set([group.id for group in self.user.profile.groups.all()])
 
         # Update the user's profile with the new points
-        Gamification().add_xp(self.user, self.base_points)
+        if self.base_points:
+            Gamification().add_xp(self.user, self.base_points)
 
     def delete(self, *args, **kwargs):
         # Before deleting the meal, deduct the points from the user's profile
@@ -222,6 +233,13 @@ class MealStreak(models.Model):
         self.last_meal_datetime = meal_datetime
 
         self.save()
+
+        return self.current_streak
+
+    def break_streak(self, meal_datetime):
+        self.current_streak = 0
+        self.last_meal_datetime = meal_datetime
+        self.save(update_fields=['current_streak', 'last_meal_datetime'])
 
         return self.current_streak
 

--- a/backend/nutrition/serializer.py
+++ b/backend/nutrition/serializer.py
@@ -63,7 +63,7 @@ class MealSerializer(serializers.ModelSerializer):
             'id', 'user', 'meal_type', 'meal_time',
             'comments', 'validation_status', 'base_points',
             'multiplier', 'proof_files', 'proofs',
-            'current_streak', 'longest_streak', 'level_up', 'fasting',
+            'current_streak', 'longest_streak', 'level_up', 'fasting', 'broke_diet',
             'total_bonus', 'total_penalty', 'bonus_list', 'penalties_list'
         ]
         # Prevent modification of automatically calculated fields

--- a/backend/nutrition/test/test_models.py
+++ b/backend/nutrition/test/test_models.py
@@ -262,12 +262,8 @@ class MealModelTest(TestCase):
             meal.clean()
 
     def test_delete_meal_removes_adjustments_and_deletes_records(self):
-<<<<<<< HEAD
         self.profile.score = 100.0
         self.profile.save()
-
-=======
->>>>>>> 369294b73fef25faeceab84f11f741dd1acdae11
         meal = Meal.objects.create(**self.meal_data)
 
         meal_content_type = ContentType.objects.get_for_model(Meal)
@@ -296,6 +292,24 @@ class MealModelTest(TestCase):
         self.assertAlmostEqual(removed_xp, expected_removed, places=5)
         self.assertFalse(GamificationBonus.objects.filter(id=bonus.id).exists())
         self.assertFalse(GamificationPenalty.objects.filter(id=penalty.id).exists())
+
+    def test_broke_diet_meal_does_not_add_xp_and_breaks_streak(self):
+        """Meal com broke_diet salva sem XP e zera streak atual."""
+        MealStreak.objects.create(
+            user=self.user,
+            current_streak=4,
+            longest_streak=4,
+            last_meal_datetime=datetime(2025, 8, 26, 8, 30)
+        )
+
+        meal = Meal.objects.create(**self.meal_data, broke_diet=True)
+
+        self.profile.refresh_from_db()
+        self.user.meal_streak.refresh_from_db()
+        self.assertTrue(meal.broke_diet)
+        self.assertEqual(meal.base_points, 0.0)
+        self.assertEqual(self.profile.score, 0.0)
+        self.assertEqual(self.user.meal_streak.current_streak, 0)
 
     def test_same_meal_type_different_day_allowed(self):
         """Test that same meal type on different day is allowed"""

--- a/backend/nutrition/test/test_views.py
+++ b/backend/nutrition/test/test_views.py
@@ -327,6 +327,34 @@ class MealsAPIViewTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @patch('nutrition.models.Status.objects.get_or_create')
+    def test_create_meal_with_broke_diet(self, mock_status):
+        """Test meal creation with diet break flag."""
+        mock_status.return_value = (self.status, True)
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse('meals-list')
+        image_file = SimpleUploadedFile(
+            "test_image.jpg",
+            b"fake image content",
+            content_type="image/jpeg"
+        )
+        meal_time = datetime.now().replace(hour=8, minute=0, second=0, microsecond=0)
+
+        response = self.client.post(url, {
+            'meal_type': self.meal_config.pk,
+            'meal_time': meal_time.isoformat(),
+            'broke_diet': 'true',
+            'proof_files': [image_file]
+        }, format='multipart')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        meal = Meal.objects.get()
+        self.assertTrue(meal.broke_diet)
+        self.assertEqual(float(meal.base_points), 0.0)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(float(self.user.profile.score), 0.0)
+
     def test_list_meals_authenticated(self):
         """Test listing meals as authenticated user"""
         self.client.force_authenticate(user=self.user)

--- a/backend/social_feed/serializers.py
+++ b/backend/social_feed/serializers.py
@@ -262,21 +262,13 @@ class ReportSerializer(serializers.ModelSerializer):
             'full_name': full_name,
         }
 
-    def get_reported_by(self, obj):
-        return self._build_user_payload(obj.reported_by)
-
-    def get_reported_post(self, obj):
-        post = obj.post
-
-        if not post and obj.comment_id and getattr(obj.comment, 'post', None):
-            post = obj.comment.post
-
+    def _build_post_payload(self, post):
         if not post:
             return None
 
         request = self.context.get('request')
         content_files = []
-        
+
         for content_file in post.content_files.all():
             file_url = content_file.file.url
             if request is not None:
@@ -294,6 +286,19 @@ class ReportSerializer(serializers.ModelSerializer):
             'created_at': post.created_at,
             'content_files': content_files,
         }
+
+    def get_reported_by(self, obj):
+        return self._build_user_payload(obj.reported_by)
+
+    def get_reported_post(self, obj):
+        post = obj.post
+
+        if not post and obj.comment_id and getattr(obj.comment, 'post', None):
+            post = obj.comment.post
+
+        if not post:
+            return None
+        return self._build_post_payload(post)
 
 
     class Meta:
@@ -348,3 +353,42 @@ class ReportUpdateSerializer(serializers.ModelSerializer):
             validated_data['resolved_at'] = timezone.now()
 
         return super().update(instance, validated_data)
+
+
+class AggregatedReportSerializer(ReportSerializer):
+    status = serializers.CharField()
+    target_id = serializers.IntegerField()
+    total_reports = serializers.IntegerField()
+    reasons = serializers.ListField()
+    first_reported_at = serializers.DateTimeField()
+    last_reported_at = serializers.DateTimeField()
+    reported_item = serializers.SerializerMethodField()
+    reported_post = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Report
+        fields = [
+            'report_type', 'target_id', 'status', 'total_reports', 'reasons',
+            'first_reported_at', 'last_reported_at', 'reported_item', 'reported_post',
+        ]
+        read_only_fields = fields
+
+    def get_reported_item(self, obj):
+        item = obj['item']
+
+        if obj['report_type'] == 'comment':
+            return {
+                'id': item.id,
+                'text': item.text,
+                'created_at': item.created_at,
+                'user': self._build_user_payload(item.user),
+                'post_id': item.post_id,
+            }
+
+        return self._build_post_payload(item)
+
+    def get_reported_post(self, obj):
+        if obj['report_type'] == 'comment':
+            return self._build_post_payload(obj['item'].post)
+
+        return self._build_post_payload(obj['item'])

--- a/backend/social_feed/test/test_urls.py
+++ b/backend/social_feed/test/test_urls.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from social_feed.views import (
     PostViewSet, CommentListCreateView, CommentDetailView,
     CommentToggleLikeView, ReportListCreateView, ReportDetailView,
+    AggregatedReportListView, AggregatedReportDetailView,
     UserPostsView
 )
 
@@ -101,6 +102,22 @@ class URLTest(TestCase):
         resolver = resolve(url)
         self.assertEqual(resolver.func.view_class, ReportDetailView)
 
+    def test_reports_grouped_list_url(self):
+        """Teste URL de listagem agregada de reports."""
+        url = reverse('social_feed:report-grouped-list')
+        self.assertEqual(url, '/api/v1/social-feed/reports/grouped/')
+
+        resolver = resolve(url)
+        self.assertEqual(resolver.func.view_class, AggregatedReportListView)
+
+    def test_reports_grouped_detail_url(self):
+        """Teste URL de detalhe agregado de reports."""
+        url = reverse('social_feed:report-grouped-detail', kwargs={'report_type': 'post', 'target_id': 1})
+        self.assertEqual(url, '/api/v1/social-feed/reports/grouped/post/1/')
+
+        resolver = resolve(url)
+        self.assertEqual(resolver.func.view_class, AggregatedReportDetailView)
+
     def test_user_posts_url(self):
         """Teste URL para posts de usuário específico."""
         url = reverse('social_feed:user-posts', kwargs={'user_id': 1})
@@ -118,6 +135,7 @@ class URLTest(TestCase):
             'comment-detail',
             'comment-toggle-like',
             'report-list-create',
+            'report-grouped-list',
             'report-detail',
             'user-posts'
         ]
@@ -126,6 +144,8 @@ class URLTest(TestCase):
             try:
                 if url_name in ['posts-detail', 'comment-detail', 'report-detail', 'comment-toggle-like']:
                     url = reverse(f'social_feed:{url_name}', kwargs={'pk': 1})
+                elif url_name == 'report-grouped-list':
+                    url = reverse(f'social_feed:{url_name}')
                 elif url_name == 'user-posts':
                     url = reverse(f'social_feed:{url_name}', kwargs={'user_id': 1})
                 else:

--- a/backend/social_feed/test/test_views.py
+++ b/backend/social_feed/test/test_views.py
@@ -418,6 +418,77 @@ class ReportViewTest(SocialFeedAPITestCase):
         self.assertEqual(len(response.data['results']), 1)
         self.assertIsNotNone(response.data['next'])
 
+    def test_admin_can_list_grouped_reports(self):
+        """Admin deve listar denúncias agrupadas por item reportado."""
+        self.client.force_authenticate(user=self.admin)
+
+        comment = Comment.objects.create(
+            user=self.user2,
+            post=self.post_1,
+            text='Comentario denunciado'
+        )
+        Report.objects.create(
+            report_type='post',
+            post=self.post_2,
+            reported_by=self.user2,
+            reason='fake',
+            status='pending'
+        )
+        Report.objects.create(
+            report_type='comment',
+            comment=comment,
+            reported_by=self.user1,
+            reason='inappropriate',
+            status='pending'
+        )
+
+        url = reverse('social_feed:report-grouped-list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 3)
+        post_group = next(item for item in response.data['results'] if item['report_type'] == 'post' and item['target_id'] == self.post_2.id)
+        self.assertEqual(post_group['total_reports'], 2)
+        self.assertEqual(post_group['status'], 'pending')
+
+    def test_non_admin_cannot_access_grouped_reports(self):
+        """Usuário comum não deve acessar moderação agregada."""
+        self.admin.is_staff = False
+        self.admin.save(update_fields=['is_staff'])
+        self.client.force_authenticate(user=self.user1)
+
+        url = reverse('social_feed:report-grouped-list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_patch_grouped_reports(self):
+        """Admin deve conseguir resolver denúncias pendentes do item em lote."""
+        self.client.force_authenticate(user=self.admin)
+
+        second_report = Report.objects.create(
+            report_type='post',
+            post=self.post_2,
+            reported_by=self.user2,
+            reason='fake',
+            status='pending'
+        )
+
+        url = reverse('social_feed:report-grouped-detail', kwargs={'report_type': 'post', 'target_id': self.post_2.id})
+        response = self.client.patch(url, {
+            'status': 'dismissed',
+            'notes': 'Conteúdo revisado',
+            'response': 'Encerrado'
+        }, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.report_user1_pending.refresh_from_db()
+        second_report.refresh_from_db()
+        self.assertEqual(self.report_user1_pending.status, 'dismissed')
+        self.assertEqual(second_report.status, 'dismissed')
+        self.assertEqual(self.report_user1_pending.notes, 'Conteúdo revisado')
+        self.assertEqual(second_report.response, 'Encerrado')
+
 
 class CommentViewTest(SocialFeedAPITestCase):
     """Testes para views de comentários."""

--- a/backend/social_feed/urls.py
+++ b/backend/social_feed/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (
     PostViewSet, CommentListCreateView, CommentDetailView, CommentToggleLikeView,
-    ReportListCreateView, ReportDetailView, UserPostsView
+    ReportListCreateView, ReportDetailView, AggregatedReportListView, AggregatedReportDetailView, UserPostsView
 )
 
 app_name = 'social_feed'
@@ -16,6 +16,8 @@ urlpatterns = [
     path('comments/<int:pk>/', CommentDetailView.as_view(), name='comment-detail'),
     path('comments/<int:pk>/toggle-like/', CommentToggleLikeView.as_view(), name='comment-toggle-like'),
     path('reports/', ReportListCreateView.as_view(), name='report-list-create'),
+    path('reports/grouped/', AggregatedReportListView.as_view(), name='report-grouped-list'),
+    path('reports/grouped/<str:report_type>/<int:target_id>/', AggregatedReportDetailView.as_view(), name='report-grouped-detail'),
     path('reports/<int:pk>/', ReportDetailView.as_view(), name='report-detail'),
     path('users/<int:user_id>/posts/', UserPostsView.as_view(), name='user-posts'),
 ]

--- a/backend/social_feed/views.py
+++ b/backend/social_feed/views.py
@@ -1,14 +1,18 @@
+from collections import Counter
+
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from django.db.models import Q
 from .models import Post, Comment, Report, PostLike, CommentLike
 from .serializers import (
     PostSerializer, PostListSerializer, PostCreateSerializer, PostUpdateSerializer,
-    CommentSerializer, ReportSerializer, ReportCreateSerializer, ReportUpdateSerializer, CommentCreateSerializer
+    CommentSerializer, ReportSerializer, ReportCreateSerializer, ReportUpdateSerializer, CommentCreateSerializer,
+    AggregatedReportSerializer,
 )
 from .pagination import PostsPagination, CommentsPagination, ReportsPagination
 
@@ -305,6 +309,129 @@ class ReportDetailView(generics.RetrieveUpdateAPIView):
                 status=403
             )
         return super().update(request, *args, **kwargs)
+
+
+class ReportAggregationMixin:
+    @staticmethod
+    def _ensure_admin(user):
+        if not (user.is_staff or user.is_superuser):
+            raise PermissionDenied('Apenas administradores podem acessar a moderação agregada.')
+
+    @staticmethod
+    def _get_group_status(reports):
+        statuses = {report.status for report in reports}
+        for candidate in ('pending', 'reviewed', 'resolved', 'dismissed'):
+            if candidate in statuses:
+                return candidate
+
+        return reports[0].status
+
+    def _build_aggregated_groups(self, reports):
+        grouped = {}
+
+        for report in reports:
+            target_id = report.comment_id if report.report_type == 'comment' else report.post_id
+            key = (report.report_type, target_id)
+            bucket = grouped.setdefault(key, [])
+            bucket.append(report)
+
+        aggregated = []
+        for (report_type, target_id), bucket in grouped.items():
+            ordered_bucket = sorted(bucket, key=lambda report: report.created_at)
+            reason_counter = Counter(report.reason for report in bucket)
+            aggregated.append({
+                'report_type': report_type,
+                'target_id': target_id,
+                'status': self._get_group_status(bucket),
+                'total_reports': len(bucket),
+                'reasons': [
+                    {'reason': reason, 'count': count}
+                    for reason, count in reason_counter.items()
+                ],
+                'first_reported_at': ordered_bucket[0].created_at,
+                'last_reported_at': ordered_bucket[-1].created_at,
+                'item': ordered_bucket[-1].comment if report_type == 'comment' else ordered_bucket[-1].post,
+                'reports': bucket,
+            })
+
+        aggregated.sort(key=lambda group: group['last_reported_at'], reverse=True)
+        return aggregated
+
+    def _get_reports_for_target(self, report_type, target_id):
+        return list(
+            Report.objects.select_related(
+                'reported_by', 'post__user', 'comment__user', 'comment__post__user'
+            ).prefetch_related(
+                'post__content_files', 'comment__post__content_files'
+            ).filter(
+                report_type=report_type,
+                **({'comment_id': target_id} if report_type == 'comment' else {'post_id': target_id})
+            )
+        )
+
+
+@extend_schema(tags=['Social Feed'])
+class AggregatedReportListView(ReportAggregationMixin, APIView):
+    permission_classes = [permissions.IsAuthenticated]
+    pagination_class = ReportsPagination
+
+    def get(self, request):
+        self._ensure_admin(request.user)
+        reports = Report.objects.select_related(
+            'reported_by', 'post__user', 'comment__user', 'comment__post__user'
+        ).prefetch_related(
+            'post__content_files', 'comment__post__content_files'
+        )
+        groups = self._build_aggregated_groups(reports)
+
+        status_filter = request.query_params.get('status')
+        if status_filter:
+            groups = [group for group in groups if group['status'] == status_filter]
+
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(groups, request, view=self)
+        serializer = AggregatedReportSerializer(page, many=True, context={'request': request})
+
+        return paginator.get_paginated_response(serializer.data)
+
+
+@extend_schema(tags=['Social Feed'])
+class AggregatedReportDetailView(ReportAggregationMixin, APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, report_type, target_id):
+        self._ensure_admin(request.user)
+        reports = self._get_reports_for_target(report_type, target_id)
+        if not reports:
+            return Response({'detail': 'Grupo de denúncias não encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+
+        payload = self._build_aggregated_groups(reports)[0]
+        serializer = AggregatedReportSerializer(payload, context={'request': request})
+        return Response(serializer.data)
+
+    def patch(self, request, report_type, target_id):
+        self._ensure_admin(request.user)
+        reports = self._get_reports_for_target(report_type, target_id)
+        if not reports:
+            return Response({'detail': 'Grupo de denúncias não encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+
+        pending_reports = [report for report in reports if report.status == 'pending']
+        if not pending_reports:
+            return Response(
+                {'detail': 'Não há denúncias pendentes para este item.'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serializer = ReportUpdateSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        for report in pending_reports:
+            ReportUpdateSerializer().update(report, serializer.validated_data.copy())
+
+        refreshed_reports = self._get_reports_for_target(report_type, target_id)
+        payload = self._build_aggregated_groups(refreshed_reports)[0]
+        response_serializer = AggregatedReportSerializer(payload, context={'request': request})
+        return Response(response_serializer.data)
 
 
 @extend_schema(tags=['Social Feed'])

--- a/backend/workouts/test/test_models.py
+++ b/backend/workouts/test/test_models.py
@@ -213,12 +213,8 @@ class WorkoutCheckinModelTest(TestCase):
 
     def test_delete_workout_removes_adjustments_and_deletes_records(self):
         """Ao excluir treino, reverte bônus/penalidades vinculados e remove os registros."""
-<<<<<<< HEAD
         self.profile.score = 100.0
         self.profile.save()
-
-=======
->>>>>>> 369294b73fef25faeceab84f11f741dd1acdae11
         workout_time = timezone.now() - timedelta(hours=2)
         checkin = WorkoutCheckin.objects.create(
             user=self.user,
@@ -262,6 +258,18 @@ class WorkoutCheckinModelTest(TestCase):
         self.assertAlmostEqual(removed_xp, expected_removed, places=5)
         self.assertFalse(GamificationBonus.objects.filter(id=bonus.id).exists())
         self.assertFalse(GamificationPenalty.objects.filter(id=penalty.id).exists())
+
+    def test_workout_under_30_minutes_gives_no_xp(self):
+        """Treino abaixo de 30 minutos não deve conceder XP."""
+        checkin = WorkoutCheckin.objects.create(
+            user=self.user,
+            workout_date=timezone.now() - timedelta(hours=1),
+            duration=timedelta(minutes=29)
+        )
+
+        self.profile.refresh_from_db()
+        self.assertEqual(checkin.base_points, 0.0)
+        self.assertEqual(self.profile.score, 0.0)
 
 
 class WorkoutCheckinProofModelTest(TestCase):


### PR DESCRIPTION
## Summary
- update workout XP to 1 point per complete 30-minute block with daily redistribution and settings defaults adjusted
- add `broke_diet` to meals, skipping XP gain and breaking meal streak when flagged
- add aggregated admin moderation endpoints for reports by reported item and count pending reports by unique item

## Testing
- `python -m py_compile` on changed backend files
- Django test suite could not run in this environment because PostgreSQL on `localhost:5433` was unavailable
